### PR TITLE
Fixing issue where custom animation would be set on exit, not on enter

### DIFF
--- a/lib/with-transition.jsx
+++ b/lib/with-transition.jsx
@@ -21,7 +21,7 @@ export default function withTransitions(Component) {
         state = {
             visible: false,
             time: OPEN_TIME,
-            animation: 'pulse'
+            animation: this.props.animation ? this.props.animation : 'pulse'
         };
 
         componentDidMount() {


### PR DESCRIPTION
As the title says, if I declare a custom animation:

`<SemanticToastContainer animation="fade left" />`

Since "**pulse**" is hardcoded, it would be considered only for the exit transition.

This PR makes sure it's considered for the enter transition as well.