### PR TITLE
Allow array of strings as description

### DIFF
--- a/lib/semantic-toast.jsx
+++ b/lib/semantic-toast.jsx
@@ -35,7 +35,11 @@ function SemanticToast(props) {
 SemanticToast.propTypes = {
     type: PropTypes.oneOf(['info', 'success', 'error', 'warning']).isRequired,
     title: PropTypes.string.isRequired,
-    description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    description: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.string, 
+        PropTypes.node
+    ]).isRequired,
     icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     onClick: PropTypes.func,
     onClose: PropTypes.func


### PR DESCRIPTION
Semantic UI message supports array of strings as `content` prop and generates a simple list from the items. I use it quite a lot and would be nice to be able to pass it to the toast. 

Right now, I'm working around this issue by passing a `Message.List` component.
Reference link: https://react.semantic-ui.com/collections/message/#types-list