### PR TITLE
Add onDismiss function option when a toast is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ setTimeout(() => {
             description: <p>This is a Semantic UI toast</p>
         },
         () => console.log('toast closed'),
-        () => console.log('toast clicked')
+        () => console.log('toast clicked'),
+        () => console.log('toast dismissed')
     );
 }, 1000);
 
@@ -60,8 +61,9 @@ setTimeout(() => {
         description: 'This is a Semantic UI toast wich waits 5 seconds before closing',
         animation: 'bounce',
         time: 5000,
+        onClose: () => alert('you close this toast'),
         onClick: () => alert('you click on the toast'),
-        onClose: () => alert('you close this toast')
+        onDismiss: () => alert('you have dismissed this toast')
     });
 }, 5000);
 ```
@@ -80,10 +82,10 @@ The type of animation can be specifed using an optional `animation` prop with an
 
 ### Toast
 
-The `toast` notification function receives a toast options object and optional close and click callbacks as function arguments:
+The `toast` notification function receives a toast options object and optional close, click and dismiss callbacks as function arguments:
 
 ```javascript
-toast(options, onClose, onClick);
+toast(options, onClose, onClick, onDismiss);
 ```
 
 #### Toast Options
@@ -96,8 +98,9 @@ toast(options, onClose, onClick);
 -   `size` - Size of toast with [semantic values](https://react.semantic-ui.com/collections/message/#variations-size)
 -   `list` - Array of strings for showing an item menu inside the toast
 -   `time` - Duration to keep the toast open, 0 to wait until closed by the user
--   `onClose` - The function that will be called when you click the toast is closed
+-   `onClose` - The function that will be called when the toast is closed (either if you have clicked the close sign or if the toast has been closed after `time` has passed)
 -   `onClick` - The function that will be called when you click on the toast
+-   `onDismiss` - The function that will be called when you click to close the toast. onClose function will be called afterwards. 
 -   `animation` - Override the default toast container animation
 
 ## License

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,7 +28,8 @@ declare module 'react-semantic-toasts' {
     const toast: (
         options: ToastOptions,
         onClose?: () => void,
-        onClick?: () => void
+        onClick?: () => void,
+        onDismiss?: () => void,
     ) => void
 
     export { SemanticToastContainer, toast, ToastOptions }

--- a/lib/semantic-toast-container.jsx
+++ b/lib/semantic-toast-container.jsx
@@ -85,6 +85,7 @@ class SemanticToastContainer extends Component {
                         color,
                         list,
                         onClick,
+                        onDismiss,
                         animation
                     } = toast;
                     return (
@@ -103,6 +104,7 @@ class SemanticToastContainer extends Component {
                             time={time}
                             onClick={onClick}
                             onClose={this.onClose}
+                            onDismiss={onDismiss}
                         />
                     );
                 })}

--- a/lib/semantic-toast.jsx
+++ b/lib/semantic-toast.jsx
@@ -11,12 +11,12 @@ const icons = {
 };
 
 function SemanticToast(props) {
-    const { type, title, description, size, color, list, onClose, onClick } = props;
+    const { type, title, description, size, color, list, onClose, onClick, onDismiss } = props;
     const icon = props.icon || icons[type];
 
-    const onDismiss = e => {
+    const onDispel = e => {
         e.stopPropagation();
-        props.onDismiss();
+        onDismiss();
         onClose();
     };
 
@@ -24,7 +24,7 @@ function SemanticToast(props) {
         <Message
             {...{ [type]: true }}
             onClick={onClick}
-            onDismiss={onDismiss}
+            onDismiss={onDispel}
             header={title}
             content={description}
             icon={icon}

--- a/lib/semantic-toast.jsx
+++ b/lib/semantic-toast.jsx
@@ -16,6 +16,7 @@ function SemanticToast(props) {
 
     const onDismiss = e => {
         e.stopPropagation();
+        props.onDismiss();
         onClose();
     };
 
@@ -48,11 +49,13 @@ SemanticToast.propTypes = {
     color: PropTypes.string,
     list: PropTypes.arrayOf(PropTypes.string),
     onClick: PropTypes.func,
+    onDismiss: PropTypes.func,
     onClose: PropTypes.func
 };
 
 SemanticToast.defaultProps = {
     onClick: undefined,
+    onDismiss: undefined,
     onClose: undefined,
     icon: undefined,
     color: undefined,

--- a/lib/toast.js
+++ b/lib/toast.js
@@ -3,9 +3,9 @@ import Store from './store';
 const store = new Store();
 let id = 0;
 
-function toast(item, onClose, onClick) {
+function toast(item, onClose, onClick, onDismiss) {
     id += 1;
-    store.add(Object.assign({ id, onClose, onClick }, item));
+    store.add(Object.assign({ id, onClose, onClick, onDismiss }, item));
 }
 
 export { toast, store };


### PR DESCRIPTION
This component is quite useful, thanks a lot! 

In my case, I wanted to perform some actions that should only be triggered once the toast was explicitely dismissed by clicking the close sign, so I've added the onDismiss support. onClose it is called either you click on the close sign or if the time passes and the toast is closed. With the onDismiss function, if you want to do specific things when the X is clicked, you now can do your stuff before the toast is closed.