### PR TITLE
Corrected default types and added auto 'cursor: pointer;'

### DIFF
--- a/lib/semantic-toast-container.jsx
+++ b/lib/semantic-toast-container.jsx
@@ -73,7 +73,7 @@ class SemanticToastContainer extends Component {
 
         return toasts.length ? (
             <div className={`ui-alerts ${position} ${className}`}>
-                {this.state.toasts.map(toast => {
+                {toasts.map(toast => {
                     const {
                         id,
                         type = 'info',

--- a/lib/semantic-toast.jsx
+++ b/lib/semantic-toast.jsx
@@ -54,9 +54,9 @@ SemanticToast.propTypes = {
 };
 
 SemanticToast.defaultProps = {
-    onClick: undefined,
-    onDismiss: undefined,
-    onClose: undefined,
+    onClick: () => undefined,
+    onDismiss: () => undefined,
+    onClose: () => undefined,
     icon: undefined,
     color: undefined,
     list: undefined,


### PR DESCRIPTION
I removed the default value of `onClick` - because `Message` from `semantic-ui-react` accepts `onClick === undefined`.


Added default value for `style={{cursor: 'pointer'}}` which can be overiden by providing your own `style` prop.

I've seen multiple projects where they have unclickable toasts just because they were too lazy to add `style={{cursor: 'pointer'}}`.