### PR TITLE
Minor fixes in package.json to solve npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     },
     "peerDependencies": {
         "react": "16.x.x",
-        "semantic-ui-react": "0.83.x || 0.84.x || 0.85.x || 0.86.x || 0.87.x"
+        "semantic-ui-react": "0.83.x || 0.84.x || 0.85.x || 0.86.x || 0.87.x || 0.88.x"
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.14.3",
+        "eslint-config-prettier": "^6.0.0",
+        "prettier-eslint": "^9.0.0",
         "semantic-ui-css": "^2.4.1"
     },
     "dependencies": {
-        "eslint-config-prettier": "^6.0.0",
-        "prettier-eslint": "^9.0.0",
         "prop-types": "^15.7.2"
     },
     "peerDependencies": {


### PR DESCRIPTION
I suggest moving eslint-config-prettier and prettier-eslint from dependencies to devDependencies to avoid ```warning "react-semantic-toasts > eslint-config-prettier@6.5.0" has unmet peer dependency "eslint@>=3.14.1"``` message.

Also react-semantic-toasts seems compatible with semantic-ui-react 0.88.1 so suggested change removes ```warning " > react-semantic-toasts@0.6.4" has incorrect peer dependency "semantic-ui-react@0.83.x || 0.84.x || 0.85.x || 0.86.x || 0.87.x".``` message.