### PR TITLE
Fix issues where withTransaction passes on too many props

### DIFF
--- a/lib/with-transition.jsx
+++ b/lib/with-transition.jsx
@@ -60,11 +60,17 @@ export default function withTransitions(Component) {
             const styles = {
                 marginBottom: '1em'
             };
+            const props = {...this.props};
+            delete props.toastId;
+            delete props.onClose;
+            delete props.openAnimation;
+            delete props.closeAnimation;
+            delete props.time;
 
             return (
                 <Transition animation={animation} duration={time} visible={visible}>
                     <div style={styles} role="presentation">
-                        <Component {...this.props} onClose={this.onClose} />
+                        <Component {...props} onClose={this.onClose} />
                     </div>
                 </Transition>
             );


### PR DESCRIPTION
Without these changes I get warnings from React that the SemanticToast
component does not have the `toastId`, `openAnimation` and `closeAnimation`
props. Passing `onClose` twice doesn't make sense either. And why to pass
`time` is unclear to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/academia-de-codigo/react-semantic-toasts/47)
<!-- Reviewable:end -->
