### PR TITLE
Update peer dependency for React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             },
             "peerDependencies": {
                 "prop-types": "^15.7.2",
-                "react": "16.x.x || 17.x.x",
+                "react": "16.x.x || 17.x.x || 18.x.x",
                 "semantic-ui-react": "*"
             }
         },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "semantic-ui-css": "^2.4.1"
     },
     "peerDependencies": {
-        "react": "16.x.x || 17.x.x",
+        "react": "16.x.x || 17.x.x || 18.x.x",
         "prop-types": "^15.7.2",
         "semantic-ui-react": "*"
     },


### PR DESCRIPTION
Closes #66 

Figured I'd do the update while I'm at it. I tested the package and everything seems fine in React 18, so I think this update can be done safely. 

Hope this can go through, would save me a legacy peer deps flag when installing :)